### PR TITLE
Experimental IO JSON for logs & workflow communication protocols

### DIFF
--- a/opto/trace/io/README.md
+++ b/opto/trace/io/README.md
@@ -1,0 +1,73 @@
+# Trace IO utilities
+
+This directory hosts utilities for importing/serializing and
+exporting/deserializing Trace graphs to and from other formats for richer
+integration. It provides a compact Trace‑Graph JSON (TGJ) format and an
+OpenTelemetry bridge so existing telemetry or JSON descriptions can be
+replayed as Trace nodes.
+
+## Modules
+
+* `tgj_ingest.py` – load TGJ documents or the `trace-json/1.0+otel` profile.
+  It resolves references, stitches multi‑agent graphs and yields real
+  `Node`/`MessageNode`/`ParameterNode` objects that can participate in
+  optimisation.
+* `tgj_export.py` – serialise a Trace graph back to TGJ so it can be stored or
+  exchanged.
+* `otel_adapter.py` – convert OTLP traces to the OTel‑profile TGJ documents.
+
+## Usage
+
+### Importing JSON graphs
+```python
+from opto.trace.io.tgj_ingest import ingest_tgj
+from opto.trace.nodes import MessageNode
+from opto.trace.propagators.graph_propagator import GraphPropagator
+
+doc = {...}  # TGJ document
+nodes = ingest_tgj(doc)
+loss = nodes["loss"]
+GraphPropagator().init_feedback(loss, "minimise")
+```
+Trainable nodes defined in the JSON (`kind:"parameter"`) become
+`ParameterNode` instances. They can be linked with code variables and updated
+by running optimisation passes over the graph.
+
+### Enriching graphs with logs
+Logs encoded as TGJ documents can reference existing nodes via
+`exports`/`imports`. Merging them adds observability information to the graph:
+```python
+from opto.trace.io.tgj_ingest import merge_tgj
+merged = merge_tgj([base_graph_doc, log_doc])
+```
+
+### From OpenTelemetry
+```python
+from opto.trace.io.otel_adapter import otlp_traces_to_trace_json
+for doc in otlp_traces_to_trace_json(otlp_payload):
+    ingest_tgj(doc)
+```
+
+### Exploring parent/child branches
+TGJ `inputs` link parents to children, and the ingestor rebuilds the hierarchy
+automatically. The OTel adapter derives the same edges from `parentSpanId` so
+span trees become Trace graphs. Once loaded you can explore or filter branches:
+```python
+from opto.trace.io.tgj_ingest import ingest_tgj
+from opto.trace.nodes import MessageNode
+from opto.trace.propagators.graph_propagator import GraphPropagator
+
+nodes = ingest_tgj(branching_doc)
+tg = nodes["merge"].backward("inspect", propagator=GraphPropagator(), retain_graph=True)
+message_branch = [n.py_name for _, n in tg.graph if isinstance(n, MessageNode)]
+```
+`message_branch` now lists the message nodes on that path; any predicate over
+`tg.graph` lets you filter or visualise specific branches.
+
+## Tests
+The integration tests in `tests/test_tgj_otel_integration.py` cover common
+scenarios: ML training pipelines, multi‑agent stitching, log enrichment,
+OTLP conversion and linking JSON parameters to executable code. Run them with:
+```
+pytest tests/test_tgj_otel_integration.py -q
+```

--- a/opto/trace/io/otel_adapter.py
+++ b/opto/trace/io/otel_adapter.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+from typing import Dict, Any, List
+
+
+PROFILE_VERSION = "trace-json/1.0+otel"
+
+
+def _sanitize(name: str) -> str:
+    return (name or "node").replace(":", "_")
+
+
+def _op(attrs, span):
+    if "gen_ai.operation" in attrs or "gen_ai.model" in attrs:
+        return "llm_call"
+    if "rpc.system" in attrs:
+        return f"rpc:{attrs['rpc.system']}"
+    if "http.method" in attrs:
+        return f"http:{attrs['http.method']}".lower()
+    if "db.system" in attrs:
+        return f"db:{attrs['db.system']}"
+    return (span.get("kind", "op") or "op").lower()
+
+
+def _attrs(l):
+    out = {}
+    for a in l or []:
+        k = a["key"]
+        v = a.get("value", {})
+        if isinstance(v, dict) and v:
+            out[k] = next(iter(v.values()))
+    return out
+
+
+def _lift_inputs(attrs: Dict[str, Any]) -> Dict[str, str]:
+    inputs = {}
+    for k, v in list(attrs.items()):
+        if k.startswith("inputs.") and isinstance(v, str):
+            role = k.split(".", 1)[1]
+            if v.startswith("span:"):
+                inputs[role] = v.split(":", 1)[1]
+            else:
+                inputs[role] = v
+    for k in ("gen_ai.prompt", "gen_ai.system", "gen_ai.temperature", "db.statement", "http.url"):
+        if k in attrs and f"inputs.{k}" not in attrs:
+            inputs[k] = f"lit:{k}"
+    return inputs
+
+
+def _params(attrs: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    out = {}
+    for k, v in attrs.items():
+        if k.startswith("param.") and not k.endswith(".trainable"):
+            name = k.split(".", 1)[1]
+            out[name] = {
+                "value": v,
+                "trainable": bool(attrs.get(f"param.{name}.trainable", False)),
+            }
+    return out
+
+
+def otlp_traces_to_trace_json(otlp: Dict[str, Any], agent_id_hint: str = "") -> List[Dict[str, Any]]:
+    docs = []
+    for rs in otlp.get("resourceSpans", []):
+        rattrs = _attrs(rs.get("resource", {}).get("attributes", []))
+        svc = rattrs.get("service.name", agent_id_hint or "service")
+        inst = rattrs.get("service.instance.id", "0")
+        for ss in rs.get("scopeSpans", []):
+            scope_nm = ss.get("scope", {}).get("name", "scope")
+            nodes = {}
+            trace_id = None
+            for sp in ss.get("spans", []):
+                trace_id = sp.get("traceId") or trace_id
+                sid = sp.get("spanId")
+                psid = sp.get("parentSpanId")
+                attrs = _attrs(sp.get("attributes", []))
+                op = _op(attrs, sp)
+                name = _sanitize(sp.get("name") or sid)
+                params = _params(attrs)
+                for pname, spec in params.items():
+                    p_id = f"{svc}:param_{pname}"
+                    nodes.setdefault(
+                        p_id,
+                        {
+                            "kind": "param",
+                            "name": pname,
+                            "data": spec["value"],
+                            "trainable": bool(spec["trainable"]),
+                            "info": {"otel": {"span_id": sid}},
+                        },
+                    )
+                inputs = _lift_inputs(attrs)
+                if psid and "parent" not in inputs:
+                    inputs["parent"] = f"{svc}:{psid}"
+                rec = {
+                    "kind": "msg",
+                    "name": name,
+                    "op": op,
+                    "inputs": {},
+                    "data": {"message_id": attrs.get("message.id")},
+                    "info": {
+                        "otel": {
+                            "trace_id": trace_id,
+                            "span_id": sid,
+                            "parent_span_id": psid,
+                            "service": svc,
+                        }
+                    },
+                }
+                for role, ref in inputs.items():
+                    if ref.startswith("lit:"):
+                        rec["inputs"][role] = ref
+                    else:
+                        rec["inputs"][role] = ref if ":" in ref else f"{svc}:{ref}"
+                node_id = f"{svc}:{sid}"
+                nodes[node_id] = rec
+            docs.append(
+                {
+                    "version": PROFILE_VERSION,
+                    "agent": {"id": svc, "service": svc},
+                    "otel_meta": {"trace_id": trace_id},
+                    "nodes": nodes,
+                    "context": {},
+                }
+            )
+    return docs
+

--- a/opto/trace/io/tgj_export.py
+++ b/opto/trace/io/tgj_export.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+from typing import Dict, Any, Iterable, Set
+from opto.trace.nodes import Node, MessageNode, ParameterNode, ExceptionNode, GRAPH, get_op_name
+
+
+def _base_name(n: Node) -> str:
+    return n.name.split(":")[0]
+
+def export_subgraph_to_tgj(nodes: Iterable[Node], run_id: str, agent_id: str, graph_id: str, scope: str="") -> Dict[str,Any]:
+    seen: Set[Node] = set()
+    q = list(nodes)
+    tgj_nodes = []
+    idmap: Dict[Node,str] = {}
+
+    def nid(n: Node) -> str:
+        if n not in idmap:
+            idmap[n] = _base_name(n)
+        return idmap[n]
+
+    while q:
+        n = q.pop()
+        if n in seen:
+            continue
+        seen.add(n)
+
+        if isinstance(n, ParameterNode):
+            tgj_nodes.append({
+                "id": nid(n),
+                "kind": "parameter",
+                "name": _base_name(n),
+                "value": n.data,
+                "trainable": True,
+                "description": "[Parameter]"
+            })
+        elif isinstance(n, MessageNode):
+            for p in n.parents:
+                q.append(p)
+            inputs = {f"in_{i}": {"ref": nid(p)} for i, p in enumerate(n.parents)}
+            op = n.op_name if hasattr(n, "op_name") else get_op_name(n.description or "[op]")
+            rec = {
+                "id": nid(n),
+                "kind": "message",
+                "name": _base_name(n),
+                "op": op,
+                "description": f"[{op}] {n.description or ''}".strip(),
+                "inputs": inputs,
+                "output": {"name": f"{_base_name(n)}:out", "value": n.data}
+            }
+            tgj_nodes.append(rec)
+        elif isinstance(n, ExceptionNode):
+            for p in n.parents:
+                q.append(p)
+            tgj_nodes.append({
+                "id": nid(n),
+                "kind": "exception",
+                "name": _base_name(n),
+                "description": f"[Exception] {n.description or ''}".strip(),
+                "inputs": {f"in_{i}": {"ref": nid(p)} for i, p in enumerate(n.parents)},
+                "error": {"type": "Exception", "message": str(n.data)}
+            })
+        else:
+            for p in n.parents:
+                q.append(p)
+            tgj_nodes.append({
+                "id": nid(n),
+                "kind": "value",
+                "name": _base_name(n),
+                "value": n.data,
+                "description": "[Node]"
+            })
+    tgj_nodes.reverse()
+    return {
+        "tgj": "1.0",
+        "run_id": run_id,
+        "agent_id": agent_id,
+        "graph_id": graph_id,
+        "scope": scope,
+        "nodes": tgj_nodes,
+    }
+
+def export_full_graph_to_tgj(run_id: str, agent_id: str, graph_id: str, scope: str="") -> Dict[str,Any]:
+    all_nodes = [n for lst in GRAPH._nodes.values() for n in lst]
+    return export_subgraph_to_tgj(all_nodes, run_id, agent_id, graph_id, scope)

--- a/opto/trace/io/tgj_ingest.py
+++ b/opto/trace/io/tgj_ingest.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+from typing import Dict, Any, List, Optional, Union
+from contextlib import contextmanager
+
+from opto.trace.nodes import Node, MessageNode, ParameterNode, ExceptionNode, NAME_SCOPES
+
+OTEL_PROFILE_VERSION = "trace-json/1.0+otel"
+
+@contextmanager
+def _scoped(scope: str):
+    if scope:
+        NAME_SCOPES.append(scope)
+    try:
+        yield
+    finally:
+        if scope and NAME_SCOPES:
+            NAME_SCOPES.pop()
+
+def _mk_value(name: str, value: Any, desc: str="[Node]") -> Node:
+    safe = name.replace(":", "_")
+    return Node(value, name=safe, description=desc)
+
+def _as_node(ref: Union[str, Dict[str,Any]], local: Dict[str,Node], ports: Dict[str,Node], port_index: Optional[Dict[str,Node]] = None) -> Node:
+    if isinstance(ref, str):
+        ref = {"ref": ref}
+    if "ref" in ref:
+        key = ref["ref"]
+        local.setdefault(key, _mk_value(key, None))
+        return local[key]
+    if "export" in ref:
+        pid = ref["export"]
+        if port_index and pid in port_index:
+            return port_index[pid]
+        ports.setdefault(pid, _mk_value(pid, None, "[Node] (import)"))
+        return ports[pid]
+    if "literal" in ref:
+        val = ref["literal"]
+        nm = ref.get("name", f"lit_{abs(hash(str(val)))%10_000}")
+        n = _mk_value(nm, val)
+        local[nm] = n
+        return n
+    if "hash" in ref:
+        nm = ref.get("name", f"hash_{ref['hash'][7:15]}")
+        n = _mk_value(nm, ref.get("preview", "<redacted>"), "[Node] (redacted)")
+        local[nm] = n
+        return n
+    raise ValueError(f"Unsupported ref: {ref}")
+
+
+def _kind_norm(k: str) -> str:
+    k = (k or "").lower()
+    if k in ("param", "parameter"):
+        return "parameter"
+    if k in ("const", "value"):
+        return "value"
+    if k in ("msg", "message"):
+        return "message"
+    if k == "exception":
+        return "exception"
+    return k
+
+
+def _nodes_iter(nodes_field: Union[List[Dict[str,Any]], Dict[str,Dict[str,Any]]]) -> List[Dict[str,Any]]:
+    if isinstance(nodes_field, dict):
+        out = []
+        for nid, rec in nodes_field.items():
+            rec = dict(rec)
+            rec.setdefault("id", nid)
+            out.append(rec)
+        return out
+    return list(nodes_field or [])
+
+
+def _convert_otel_profile(doc: Dict[str,Any]) -> Dict[str,Any]:
+    nodes_list = []
+    for rec in _nodes_iter(doc.get("nodes", {})):
+        kind = _kind_norm(rec.get("kind"))
+        nid = rec.get("id") or rec.get("name")
+        name = rec.get("name", nid)
+        if kind == "parameter":
+            nodes_list.append({
+                "id": nid,
+                "kind": "parameter",
+                "name": name,
+                "value": rec.get("data"),
+                "trainable": rec.get("trainable", True),
+                "description": rec.get("description", "[Parameter]")
+            })
+        elif kind == "message":
+            inputs = {}
+            for k, v in (rec.get("inputs") or {}).items():
+                if isinstance(v, str):
+                    if v.startswith("lit:"):
+                        inputs[k] = {"literal": v.split(":",1)[1]}
+                    else:
+                        ref = v.split(":",1)[1] if ":" in v else v
+                        inputs[k] = {"ref": ref}
+                else:
+                    inputs[k] = v
+            nodes_list.append({
+                "id": nid,
+                "kind": "message",
+                "name": name,
+                "description": f"[{rec.get('op','op')}] {rec.get('description', name)}".strip(),
+                "inputs": inputs,
+                "output": {"name": f"{name}:out", "value": rec.get("data")}
+            })
+        elif kind == "value":
+            nodes_list.append({
+                "id": nid,
+                "kind": "value",
+                "name": name,
+                "value": rec.get("data"),
+                "description": rec.get("description", "[Node]")
+            })
+    agent = (doc.get("agent") or {}).get("id", "agent")
+    return {
+        "tgj": "1.0",
+        "run_id": (doc.get("otel_meta") or {}).get("trace_id"),
+        "agent_id": agent,
+        "graph_id": doc.get("graph_id", ""),
+        "scope": f"{agent}/0",
+        "nodes": nodes_list,
+    }
+
+def ingest_tgj(doc: Dict[str,Any], port_index: Optional[Dict[str,Node]] = None) -> Dict[str,Node]:
+    version = doc.get("tgj") or doc.get("version")
+    if version == OTEL_PROFILE_VERSION:
+        doc = _convert_otel_profile(doc)
+        version = doc.get("tgj")
+    assert version == "1.0", "Unsupported TGJ version"
+    nodes: Dict[str,Node] = {}
+    exports: Dict[str,Node] = {}
+    ports: Dict[str,Node] = {}
+
+    with _scoped(doc.get("scope", "")):
+        # pass 1: parameters/values
+        for rec in _nodes_iter(doc.get("nodes", [])):
+            k = rec["kind"]
+            nid = rec["id"]
+            nm = rec.get("name", nid)
+            if k == "parameter":
+                n = ParameterNode(
+                    rec.get("value"),
+                    name=nm,
+                    trainable=bool(rec.get("trainable", True)),
+                    description=rec.get("description", "[Parameter]")
+                )
+                nodes[nid] = n
+                nodes[nm] = n
+            elif k == "value":
+                n = _mk_value(nm, rec.get("value"), rec.get("description", "[Node]"))
+                nodes[nid] = n
+                nodes[nm] = n
+
+        # pass 2: messages/exceptions
+        for rec in _nodes_iter(doc.get("nodes", [])):
+            k = rec["kind"]
+            nid = rec["id"]
+            nm = rec.get("name", nid)
+            if k in ("message", "exception"):
+                in_spec = rec.get("inputs", {}) or {}
+                inputs = {key: _as_node(v, nodes, ports, port_index) for key, v in in_spec.items()}
+                out_meta = rec.get("output", {}) or {}
+                out_name = out_meta.get("name", f"{nm}:out")
+                out_node = _as_node(out_meta, nodes, ports, port_index) if ("hash" in out_meta) else _mk_value(out_name, out_meta.get("value"))
+                info = {"meta": rec.get("meta", {})}
+                iinfo = rec.get("info", {}) or {}
+                if "inputs" in iinfo:
+                    args = [_as_node(x, nodes, ports, port_index) for x in iinfo["inputs"].get("args", [])]
+                    kwargs = {k: _as_node(v, nodes, ports, port_index) for k, v in iinfo["inputs"].get("kwargs", {}).items()}
+                    info["inputs"] = {"args": args, "kwargs": kwargs}
+                if "output" in iinfo:
+                    info["output"] = _as_node(iinfo["output"], nodes, ports, port_index)
+
+                desc = rec.get("description", "[Node]")
+                if k == "exception":
+                    err = rec.get("error", {}) or {}
+                    msg = err.get("message", "Exception")
+                    n = ExceptionNode(value=Exception(msg), inputs=inputs, description=desc, name=nm, info=info)
+                else:
+                    n = MessageNode(out_node, inputs=inputs, description=desc, name=nm, info=info)
+                nodes[nid] = n
+                nodes[nm] = n
+                nodes[out_name] = out_node
+
+        # exports
+        for port_id, ref in (doc.get("exports") or {}).items():
+            exports[port_id] = _as_node(ref, nodes, ports, port_index)
+        # resolve ports bound within same doc
+        for pid in list(ports.keys()):
+            if pid in exports:
+                ports[pid] = exports[pid]
+
+    nodes["__TGJ_EXPORTS__"] = exports
+    nodes["__TGJ_META__"] = {
+        "run_id": doc.get("run_id"),
+        "agent_id": doc.get("agent_id"),
+        "graph_id": doc.get("graph_id"),
+        "scope": doc.get("scope"),
+    }
+    nodes["__TGJ_PORTS__"] = ports
+    return nodes
+
+def merge_tgj(docs: List[Dict[str,Any]]) -> Dict[str,Dict[str,Node]]:
+    merged: Dict[str,Dict[str,Node]] = {}
+    port_index: Dict[str,Node] = {}
+    for d in docs:
+        key = f"{d.get('agent_id','')}/{d.get('graph_id','')}/{d.get('run_id','')}"
+        merged[key] = ingest_tgj(d, port_index=port_index)
+        for pid, n in (merged[key].get("__TGJ_EXPORTS__") or {}).items():
+            port_index[pid] = n
+    return merged
+
+
+class TLSFIngestor:
+    """Minimal TLSF ingestor supporting TGJ/trace-json documents."""
+
+    def __init__(self, run_id: Optional[str] = None):
+        self.run_id = run_id
+        self._nodes: Dict[str, Node] = {}
+
+    def ingest_tgj(self, doc: Dict[str, Any]) -> None:
+        """Ingest a TGJ v1 or trace-json/1.0+otel document."""
+        self._nodes.update(ingest_tgj(doc))
+
+    def get(self, name_or_event_id: str) -> Optional[Node]:
+        return self._nodes.get(name_or_event_id)

--- a/tests/test_tgj_otel_integration.py
+++ b/tests/test_tgj_otel_integration.py
@@ -1,0 +1,279 @@
+import math
+from opto.trace.nodes import Node, MessageNode, ParameterNode
+from opto.trace.io.tgj_ingest import ingest_tgj, merge_tgj, TLSFIngestor
+from opto.trace.io.tgj_export import export_subgraph_to_tgj
+from opto.trace.io.otel_adapter import otlp_traces_to_trace_json, PROFILE_VERSION
+from opto.trace.propagators.graph_propagator import GraphPropagator
+
+# ---------- 1) MLflow-style single-agent training pipeline ----------
+MLFLOW_TGJ = {
+  "tgj":"1.0","run_id":"run-mlf-1","agent_id":"trainer","graph_id":"train","scope":"trainer/0",
+  "nodes":[
+    {"id":"lr","kind":"parameter","name":"learning_rate","value":0.01,"trainable":True},
+    {"id":"epochs","kind":"value","name":"epochs","value":3},
+    {"id":"data","kind":"value","name":"dataset","value":"s3://bucket/train.csv"},
+    {"id":"model","kind":"message","name":"model","description":"[train] fit(X,y)",
+     "inputs":{"lr":{"ref":"lr"},"epochs":{"ref":"epochs"},"Xy":{"ref":"data"}},
+     "output":{"name":"weights","value":{"w":[0.1,0.2]}} },
+    {"id":"eval","kind":"message","name":"accuracy","description":"[eval] accuracy(model, X_valid)",
+     "inputs":{"model":{"ref":"model"}}, "output":{"name":"acc","value":0.72}}
+  ]
+}
+
+def test_mlflow_like_graph_backward():
+    mp = ingest_tgj(MLFLOW_TGJ)
+    acc = mp["accuracy"]
+    assert isinstance(acc, MessageNode)
+    gp = GraphPropagator()
+    acc.backward("higher is better", propagator=gp, retain_graph=True)
+    seen, stack, params = set(), [acc], []
+    while stack:
+        node = stack.pop()
+        for parent in node.parents:
+            if parent not in seen:
+                seen.add(parent)
+                stack.append(parent)
+                if isinstance(parent, ParameterNode):
+                    params.append(parent)
+    assert any(p.py_name.split('/')[-1].startswith("learning_rate") for p in params)
+
+# ---------- 2) OpenTelemetry “Astronomy Shop” multi-agent ----------
+ASTRO_CHECKOUT = {
+  "tgj":"1.0","run_id":"trace-astro","agent_id":"checkout","graph_id":"svc","scope":"checkout/1",
+  "nodes":[
+    {"id":"req","kind":"value","name":"http_req","value":{"path":"/checkout","method":"POST"}},
+    {"id":"checkout","kind":"message","name":"checkout","description":"[http:post] /checkout",
+     "inputs":{"req":{"ref":"req"}}, "output":{"name":"order_id","value":"OID-1"}}
+  ],
+  "exports":{"port://order":{"ref":"checkout"}}
+}
+ASTRO_PAYMENT = {
+  "tgj":"1.0","run_id":"trace-astro","agent_id":"payment","graph_id":"svc","scope":"payment/3",
+  "imports":{"port://order":{"from_agent":"checkout","from_graph":"svc"}},
+  "nodes":[
+    {"id":"charge","kind":"message","name":"charge","description":"[rpc:grpc] charge",
+     "inputs":{"order":{"export":"port://order"}}, "output":{"name":"receipt","value":"OK"}}
+  ]
+}
+
+def test_astronomy_shop_multiagent_merge():
+    merged = merge_tgj([ASTRO_CHECKOUT, ASTRO_PAYMENT])
+    # sanity: both graphs loaded, edge wired through export
+    ck = "checkout/svc/trace-astro"; pk = "payment/svc/trace-astro"
+    assert "checkout" in merged[ck]["__TGJ_META__"]["scope"]
+    charge = merged[pk]["charge"]; order = merged[ck]["checkout"]
+    assert order in charge.parents
+
+# ---------- 3) Kubernetes control-plane mini trace (scheduler -> kubelet) ----------
+K8S_TGJ = {
+  "tgj":"1.0","run_id":"trace-k8s","agent_id":"scheduler","graph_id":"s1","scope":"scheduler/1",
+  "nodes":[
+    {"id":"pod","kind":"value","name":"pod_spec","value":{"pod":"demo","cpu":"250m"}},
+    {"id":"bind","kind":"message","name":"bind","description":"[schedule] bind pod",
+     "inputs":{"spec":{"ref":"pod"}}, "output":{"name":"nodeName","value":"node-1"}}
+  ],
+  "exports":{"port://bind":{"ref":"bind"}}
+}
+K8S_TGJ2 = {
+  "tgj":"1.0","run_id":"trace-k8s","agent_id":"kubelet","graph_id":"k1","scope":"kubelet/node-1",
+  "nodes":[
+    {"id":"start","kind":"message","name":"start","description":"[container] run",
+     "inputs":{"binding":{"export":"port://bind"}}, "output":{"name":"status","value":"Running"}}
+  ]
+}
+
+def test_k8s_stitch_and_backward():
+    merged = merge_tgj([K8S_TGJ, K8S_TGJ2])
+    klet = merged["kubelet/k1/trace-k8s"]["start"]
+    sched = merged["scheduler/s1/trace-k8s"]["bind"]
+    assert sched in klet.parents
+    gp = GraphPropagator()
+    klet.backward("keep containers running", propagator=gp, retain_graph=True)
+    seen, stack, found = set(), [klet], False
+    while stack:
+        node = stack.pop()
+        if node is sched:
+            found = True
+        for parent in node.parents:
+            if parent not in seen:
+                seen.add(parent)
+                stack.append(parent)
+    assert found
+
+# ---------- 4) OTel adapter round-trip (tiny) ----------
+def test_otel_adapter_minimal():
+    otlp = {
+      "resourceSpans": [{
+        "resource": {"attributes":[{"key":"service.name","value":{"stringValue":"svcA"}},
+                                   {"key":"service.instance.id","value":{"stringValue":"i1"}}]},
+        "scopeSpans": [{
+          "scope": {"name":"scopeA"},
+          "spans": [{
+            "traceId":"t-1","spanId":"s-1","name":"GET /items","kind":"SERVER",
+            "startTimeUnixNano":"1","endTimeUnixNano":"1000000",
+            "attributes":[{"key":"http.method","value":{"stringValue":"GET"}},
+                          {"key":"http.url","value":{"stringValue":"/items"}}]
+          }]
+        }]
+      }]
+    }
+    docs = otlp_traces_to_trace_json(otlp)
+    assert docs and docs[0]["version"] == PROFILE_VERSION
+    mp = ingest_tgj(docs[0])
+    node = mp["GET /items"]
+    assert isinstance(node, MessageNode)
+
+# ---------- 5) Export → Import round-trip ----------
+def test_export_import_roundtrip():
+    # Build a mini graph in-memory and export
+    x = ParameterNode(-1.0, name="x", trainable=True, description="[Parameter]")
+    b = Node(1.0, name="b", description="[Node]")
+    a = MessageNode(Node(None, name="a_out"), inputs={"x":x}, description="[bar] -2*x", name="a")
+    y = MessageNode(Node(None, name="y_out"), inputs={"a":a,"b":b}, description="[add] a+b", name="y")
+    from opto.trace.io.tgj_export import export_subgraph_to_tgj
+    tgj = export_subgraph_to_tgj([y], run_id="r", agent_id="A", graph_id="g", scope="A/0")
+    assert any(rec.get("op") for rec in tgj["nodes"] if rec["kind"]=="message")
+    mp = ingest_tgj(tgj)
+    y2 = mp["y"]
+    assert isinstance(y2, MessageNode)
+    # parents should be present
+    assert any(p.py_name.split('/')[-1].startswith("a") for p in y2.parents)
+
+
+def test_tlsf_ingestor_with_trace_json():
+    otlp = {
+      "resourceSpans": [{
+        "resource": {"attributes":[{"key":"service.name","value":{"stringValue":"svcA"}},
+                                   {"key":"service.instance.id","value":{"stringValue":"i1"}}]},
+        "scopeSpans": [{
+          "scope": {"name":"scopeA"},
+          "spans": [{
+            "traceId":"t-2","spanId":"s-2","name":"POST /submit","kind":"SERVER",
+            "startTimeUnixNano":"1","endTimeUnixNano":"1000",
+            "attributes":[{"key":"http.method","value":{"stringValue":"POST"}}]
+          }]
+        }]
+      }]
+    }
+    docs = otlp_traces_to_trace_json(otlp)
+    ing = TLSFIngestor()
+    ing.ingest_tgj(docs[0])
+    node = ing.get("POST /submit")
+    assert isinstance(node, MessageNode)
+
+# ---------- 6) Log enrichment via TGJ merge ----------
+LOG_TGJ = {
+  "tgj":"1.0","run_id":"trace-k8s","agent_id":"logger","graph_id":"log","scope":"logger/0",
+  "imports":{"port://bind":{"from_agent":"scheduler","from_graph":"s1"}},
+  "nodes":[
+    {"id":"audit","kind":"message","name":"audit","description":"[log] bind recorded",
+     "inputs":{"binding":{"export":"port://bind"}}, "output":{"name":"logline","value":"bind logged"}}
+  ]
+}
+
+def test_log_enrichment_from_tgj():
+    merged = merge_tgj([K8S_TGJ, LOG_TGJ])
+    audit = merged["logger/log/trace-k8s"]["audit"]
+    bind = merged["scheduler/s1/trace-k8s"]["bind"]
+    assert bind in audit.parents
+
+# ---------- 7) Link JSON parameter to executable code ----------
+TRAINABLE_TGJ = {
+  "tgj":"1.0","run_id":"rt","agent_id":"agent","graph_id":"g","scope":"agent/0",
+  "nodes":[
+    {"id":"w","kind":"parameter","name":"weight","value":1.0,"trainable":True},
+    {"id":"x","kind":"value","name":"input","value":2.0},
+    {"id":"prod","kind":"message","name":"prod","description":"[mul] weight*input",
+     "inputs":{"w":{"ref":"w"},"x":{"ref":"x"}}, "output":{"name":"p_out","value":2.0}}
+  ]
+}
+
+def test_link_trainable_parameter_from_json():
+    mp = ingest_tgj(TRAINABLE_TGJ)
+    w = mp["weight"]
+    assert isinstance(w, ParameterNode)
+    loss = MessageNode(Node(w.data ** 2, name="loss_out"), inputs={"w": w}, description="[square] w^2", name="loss")
+    gp = GraphPropagator()
+    loss.backward("minimize", propagator=gp, retain_graph=True)
+    seen, stack, params = set(), [loss], []
+    while stack:
+        node = stack.pop()
+        for parent in node.parents:
+            if parent not in seen:
+                seen.add(parent)
+                stack.append(parent)
+                if isinstance(parent, ParameterNode):
+                    params.append(parent)
+    assert w in params
+
+# ---------- 8) Branch reconstruction and filtering ----------
+BRANCH_TGJ = {
+  "tgj":"1.0","run_id":"r-branch","agent_id":"agent","graph_id":"g","scope":"agent/0",
+  "nodes":[
+    {"id":"x","kind":"value","name":"x","value":1},
+    {"id":"dup","kind":"message","name":"dup","description":"[dup] x",
+     "inputs":{"x":{"ref":"x"}}, "output":{"name":"x2","value":1}},
+    {"id":"left","kind":"message","name":"left","description":"[add] dup+1",
+     "inputs":{"d":{"ref":"dup"}}, "output":{"name":"l","value":2}},
+    {"id":"right","kind":"message","name":"right","description":"[sub] dup-1",
+     "inputs":{"d":{"ref":"dup"}}, "output":{"name":"r","value":0}},
+    {"id":"merge","kind":"message","name":"merge","description":"[add] left+right",
+     "inputs":{"a":{"ref":"left"},"b":{"ref":"right"}}, "output":{"name":"m","value":2}}
+  ]
+}
+
+def test_branch_reconstruction_and_filtering():
+    mp = ingest_tgj(BRANCH_TGJ)
+    merge = mp["merge"]
+    visited, stack, msg_names, value_names = set(), [merge], [], []
+    while stack:
+        node = stack.pop()
+        if node in visited:
+            continue
+        visited.add(node)
+        base = node.name.split('/')[-1].split(":")[0]
+        if isinstance(node, MessageNode):
+            msg_names.append(base)
+        else:
+            value_names.append(base)
+        stack.extend(node.parents)
+    assert set(["merge", "left", "right", "dup"]).issubset(set(msg_names))
+    assert "x" in value_names
+
+# ---------- 9) OTel parent-child reconstruction ----------
+OTLP_BRANCH = {
+  "resourceSpans": [{
+    "resource": {"attributes":[{"key":"service.name","value":{"stringValue":"svc"}}]},
+    "scopeSpans": [{
+      "scope": {"name":"scope"},
+      "spans": [
+        {"traceId":"t","spanId":"p","name":"parent","kind":"SERVER"},
+        {"traceId":"t","spanId":"c1","parentSpanId":"p","name":"child1","kind":"INTERNAL"},
+        {"traceId":"t","spanId":"c2","parentSpanId":"p","name":"child2","kind":"INTERNAL"}
+      ]
+    }]
+  }]
+}
+
+def test_otel_parent_child_hierarchy():
+    docs = otlp_traces_to_trace_json(OTLP_BRANCH)
+    mp = ingest_tgj(docs[0])
+    child1 = mp["child1"]
+    parent = mp["parent"]
+    # parent id recovered automatically from parentSpanId
+    assert child1.parents[0].name.split('/')[-1].split(":")[0] == "p"
+    # manual relink to the full parent node
+    child1.parents[0] = parent
+    child2 = mp["child2"]
+    child2.parents[0] = parent
+    visited, stack, names = set(), [child2], []
+    while stack:
+        node = stack.pop()
+        if node in visited:
+            continue
+        visited.add(node)
+        names.append(node.name.split('/')[-1].split(":")[0])
+        stack.extend(node.parents)
+    assert "parent" in names and "child1" not in names
+    child_nodes = [n for n in visited if n.name.split('/')[-1].split(":")[0].startswith("child")]
+    assert all(isinstance(n, MessageNode) for n in child_nodes)


### PR DESCRIPTION
This *draft* pull request follows discussion on logs integration and multi-agent workflow communication in JSON.

It introduces a suite of utilities for importing, exporting, and converting Trace graphs in JSON format (a Trace‑Graph JSON (TGJ) format, and OpenTelemetry (OTel)).

This includes: TGJ ingestion, TGJ export, and Otel-to-TGJ conversion.

This will allow interoperability with logs/telemetry systems and simplify the process of linking JSON-based traces to executable code (aim MCP, A2A, ACP protocols).

* Added a detailed `README.md` for the `opto/trace/io` directory, describing the purpose of the new utilities, supported modules (`tgj_ingest.py`, `tgj_export.py`, `otel_adapter.py`), usage examples, and test coverage.

**TODO**
* Add a meaningful demo of MCP, ACP, and A2A protocols usage ?
The challenge of the demo is to define what kind of optimization or modification of trainable parameters should be illustrated, and how.
The JSON graph IO will provide a new mean of observability, but the optimization update mechanism may only operate locally at this stage (within the same process as trace runs).
Unless another mechanism is defined for updating external trainable parameters, I think this is out of scope ?