### PR TITLE
Add compress_candidate_memory method to PrioritySearch

### DIFF
--- a/examples/priority_search_on_convex_fn.py
+++ b/examples/priority_search_on_convex_fn.py
@@ -255,7 +255,7 @@ trainer.train(
     guide=guide,
     num_candidates=4,
     num_proposals=2,
-    short_term_memory_duration=2,
+    memory_update_frequency=2,
     optimizer_kwargs={'objective':"You have a task of guessing two numbers. You should make sure your guess minimizes y.",
                      'memory_size': 10}
 )

--- a/opto/features/priority_search/priority_search.py
+++ b/opto/features/priority_search/priority_search.py
@@ -799,7 +799,7 @@ class PrioritySearch(SearchTemplate):
         def _process_rollout(rollout):
             # rollout is a dict containing module, x, info, target, score, feedback
             for k in rollout:
-                if k not in ['score', 'feedback']:
+                if k not in ['score']:
                     rollout[k] = None
         candidate = copy.copy(candidate)  # make a copy of the candidate to avoid modifying the original one
         candidate.rollouts = copy.deepcopy(candidate.rollouts)  # deep copy the rollouts to avoid modifying the original one

--- a/opto/features/priority_search/priority_search_with_regressor.py
+++ b/opto/features/priority_search/priority_search_with_regressor.py
@@ -7,10 +7,10 @@ from opto.features.priority_search.priority_search import PrioritySearch, Module
 import heapq
 
 class PrioritySearch_with_Regressor(PrioritySearch):
-    """ 
+    """
     A subclass of PrioritySearch that uses a regressor to predict the scores of the candidates.
     """
-    
+
     def train(self,
               guide, # guide to provide feedback
               train_dataset,  # dataset of (x, info) pairs to train the agent
@@ -40,7 +40,7 @@ class PrioritySearch_with_Regressor(PrioritySearch):
               use_best_candidate_to_explore: bool = True,  # whether to use the best candidate as part of the exploration candidates
               memory_size: Optional[int] = None,  # size of the long-term heap memory to store the candidates; if None, no limit is set
               short_term_memory_size: Optional[int] = None,  # size of the short-term memory to store the most recent candidates; if None, no limit is set
-              short_term_memory_duration: Optional[int] = 0,  # number of iterations to keep the candidates in the short-term memory before merging them into the long-term memory. 0 means only long-term memory is used.
+              memory_update_frequency: Optional[int] = 0,  # number of iterations to keep the candidates in the short-term memory before merging them into the long-term memory. 0 means only long-term memory is used.
               score_function: str = 'mean',  # function to compute the score for the candidates; 'mean' or 'ucb'
               ucb_exploration_constant: float = 1.0,  # exploration constant for UCB score function
               # Regressor specific parameters
@@ -77,9 +77,9 @@ class PrioritySearch_with_Regressor(PrioritySearch):
             ucb_exploration_constant=ucb_exploration_constant,
             memory_size=memory_size,
             short_term_memory_size=short_term_memory_size,
-            short_term_memory_duration=short_term_memory_duration
+            memory_update_frequency=memory_update_frequency
         )
-        
+
         # Initialize the regressor with the long-term memory and custom parameters - this is the only difference from parent class
         self.regressor = ModuleCandidateRegressor(
             memory=self.long_term_memory,
@@ -129,7 +129,7 @@ class PrioritySearch_with_Regressor(PrioritySearch):
             while len(self.memory) < min(max_mem_size, self.num_candidates):
                 self.memory.push(self.max_score, ModuleCandidate(self.agent, optimizer=self.optimizer))  # Push the base agent as the first candidate (This gives the initialization of the priority queue)
 
-        
+
         self.update_memory_with_regressor(verbose=verbose, **kwargs)
 
         # TODO Log information about the update
@@ -179,7 +179,7 @@ class PrioritySearch_with_Regressor(PrioritySearch):
         """
         print("--- Updating memory with validation results...") if verbose else None
         for candidate, rollouts in validate_results.items():
-            candidate.add_rollouts(rollouts)  # add the rollouts to the 
+            candidate.add_rollouts(rollouts)  # add the rollouts to the
             placeholder_priority = self.max_score
             self.memory.push(placeholder_priority, candidate)
 

--- a/tests/unit_tests/test_priority_search.py
+++ b/tests/unit_tests/test_priority_search.py
@@ -55,6 +55,7 @@ dataset = {'inputs': xs, 'infos': infos}
 num_proposals = 10
 num_candidates = 5
 long_term_memory_size = 3
+memory_update_frequency = 2
 suggested_value = 5
 
 
@@ -86,6 +87,14 @@ class PrioritySearch(_PrioritySearch):
 
     def exploit(self, **kwargs):
         print("[UnitTest] Exploit at iteration:", self.n_iters)
+        # if self.memory is self.long_term_memory and self.n_iters > 0:
+        #     for _, c in self.long_term_memory.memory:
+        #         for rollout in c.rollouts:
+        #             assert rollout['x'] is None
+        #             assert rollout['info'] is None
+        #             assert rollout['target'] is None
+        #             assert rollout['module'] is None
+
         candidate, priority, info_dict = super().exploit(**kwargs)
         assert isinstance(candidate, ModuleCandidate), "Expected candidate to be an instance of ModuleCandidate"
         assert isinstance(info_dict, dict), "Expected info_dict to be a dictionary"
@@ -163,6 +172,7 @@ def test_priority_search():
         num_candidates=num_candidates,
         num_proposals=num_proposals,
         long_term_memory_size=long_term_memory_size,
+        memory_update_frequency=memory_update_frequency,
         num_epochs=num_epochs,
         verbose=False, #'output',
     )
@@ -203,6 +213,7 @@ def test_resume():
         num_candidates=num_candidates,
         num_proposals=num_proposals,
         long_term_memory_size=long_term_memory_size,
+        memory_update_frequency=memory_update_frequency,
         verbose=False, #'output',
         save_path=save_path,
         save_frequency=1,
@@ -242,6 +253,7 @@ def test_trainer_train_and_resume():
         num_candidates=num_candidates,
         num_proposals=num_proposals,
         long_term_memory_size=long_term_memory_size,
+        memory_update_frequency=memory_update_frequency,
         verbose=False, #'output',
         save_path="./test_priority_search_save_trainer",
         save_frequency=1,


### PR DESCRIPTION
Add a processing method to throw away raw logs in storing to long term memory. 

The desired behavior: 
Short-term memory stores full information. 
Long-term memory stores less information (to avoid memory overflow). 

The user can set the memory size of both, update frequency, and whether to use only long/short-term memory.