### PR TITLE
Fix/graph memory overflow

### DIFF
--- a/opto/trace/bundle.py
+++ b/opto/trace/bundle.py
@@ -647,6 +647,18 @@ class FunModule(Module):
     def detach(self):
         return copy.deepcopy(self)
 
+    def __deepcopy__(self, memo):
+        # deepcopy everything except for _ldict
+        cls = self.__class__
+        result = cls.__new__(cls)
+        memo[id(self)] = result
+        for k, v in self.__dict__.items():
+            if k == "_ldict":
+                setattr(result, k, v.copy())  # reset _ldict
+            else:
+                setattr(result, k, copy.deepcopy(v, memo))
+        return result
+
     def generate_comment(
         self,
         code: str,

--- a/opto/trace/containers.py
+++ b/opto/trace/containers.py
@@ -57,11 +57,10 @@ class ParameterContainer(NodeContainer):
                     method = attr.func
                     cls_method = False
                 if trainable_method(method):
-                    if not cls_method:
-                        raise ValueError(
-                            "A trainable method cannot be a wrapped by functools.partial."
-                        )
-                    parameters[name] = method.parameter
+                    raise ValueError(
+                        "A trainable method cannot be a wrapped by functools.partial."
+                    )
+
             elif isinstance(attr, FunModule):
                 # when a bundle method is not trainable
                 # it shows up as a FunModule attribute
@@ -100,13 +99,9 @@ class ParameterContainer(NodeContainer):
                     method = attr.func
 
                 if trainable_method(method):
-                    new_attr = getattr(new_container, name)
-                    if cls_method:
-                        setattr(new_attr.func.__self__, 'parameter', method.parameter)
-                    else:
-                        raise ValueError(
-                            "A trainable method cannot be a wrapped by functools.partial."
-                        )
+                    raise ValueError(
+                        "A trainable method cannot be a wrapped by functools.partial."
+                    )
             elif trainable_method(attr):  # method attribute
                 new_attr = getattr(new_container, name)
                 new_attr.parameter = attr.parameter

--- a/opto/trace/nodes.py
+++ b/opto/trace/nodes.py
@@ -68,6 +68,7 @@ class Graph:
     """
 
     TRACE = True  # When True, we trace the graph when creating MessageNode. When False, we don't trace the graph.
+    LEGACY_GRAPH_BEHAVIOR = False  # When True, we use the legacy graph behavior where nodes are not copied when used in multiple places.
 
     def __init__(self):
         """Initialize the Graph object.
@@ -111,7 +112,12 @@ class Graph:
         name, _ = node.name.split(":")
         if len(NAME_SCOPES) > 0:
             name = NAME_SCOPES[-1] + "/" + name
-        self._nodes[name].append(node)
+
+        if self.LEGACY_GRAPH_BEHAVIOR:
+            self._nodes[name].append(node)
+        else:
+            self._nodes[name].append(id(node))  # Store the id of the node to avoid memory issues
+
         node._name = (
             name + ":" + str(len(self._nodes[name]) - 1)
         )  # NOTE assume elements in self._nodes never get removed.
@@ -131,6 +137,9 @@ class Graph:
             The function assumes that the '_nodes' attribute is a dictionary where each key is a node name and the corresponding value is a list of nodes.
             The 'id' should be a valid index within the list of nodes for the given 'name'.
         """
+        if not self.LEGACY_GRAPH_BEHAVIOR:
+            raise ValueError("Graph.get is not supported when LEGACY_GRAPH_BEHAVIOR is False.")
+
         name, id = name.split(":")
         return self._nodes[name][int(id)]
 
@@ -141,6 +150,8 @@ class Graph:
         Returns:
             list: A list of all root nodes in the graph. A root node is identified by its `is_root` attribute.
         """
+        if not self.LEGACY_GRAPH_BEHAVIOR:
+            raise ValueError("Graph.roots is not supported when LEGACY_GRAPH_BEHAVIOR is False.")
         return [v for vv in self._nodes.values() for v in vv if v.is_root]
 
     def __str__(self):

--- a/opto/trace/nodes.py
+++ b/opto/trace/nodes.py
@@ -68,14 +68,17 @@ class Graph:
     """
 
     TRACE = True  # When True, we trace the graph when creating MessageNode. When False, we don't trace the graph.
-    LEGACY_GRAPH_BEHAVIOR = False  # When True, we use the legacy graph behavior where nodes are not copied when used in multiple places.
+    LEGACY_GRAPH_BEHAVIOR = False  # When True, we use the legacy graph behavior where nodes are stored in lists. When False, we only store the count of nodes to save memory.
 
     def __init__(self):
         """Initialize the Graph object.
 
         The initialization sets up the `_nodes` attribute as a defaultdict of lists to store nodes by their names.
         """
-        self._nodes = defaultdict(list)  # a lookup table to find nodes by name
+        if self.LEGACY_GRAPH_BEHAVIOR:
+            self._nodes = defaultdict(list)  # a lookup table to find nodes by name
+        else:
+            self._nodes = defaultdict(lambda: 0)  # a lookup table to find nodes by name
 
     def clear(self):
         """Remove all nodes from the graph.
@@ -89,10 +92,12 @@ class Graph:
             The function is called in unit tests to reset the state of the graph between test cases,
             ensuring that each test runs with a clean slate and is not affected by the state left by previous tests.
         """
-        for node in self._nodes.values():
-            del node
-        self._nodes = defaultdict(list)
-        # self._levels = defaultdict(list)
+        if self.LEGACY_GRAPH_BEHAVIOR:
+            for node in self._nodes.values():
+                del node
+            self._nodes = defaultdict(list)
+        else:
+            self._nodes = defaultdict(lambda: 0)
 
     def register(self, node):
         """Add a node to the graph.
@@ -116,12 +121,32 @@ class Graph:
         if self.LEGACY_GRAPH_BEHAVIOR:
             self._nodes[name].append(node)
         else:
-            self._nodes[name].append(id(node))  # Store the id of the node to avoid memory issues
+            self._nodes[name] += 1  # Store the id of the node to avoid memory issues
 
         node._name = (
-            name + ":" + str(len(self._nodes[name]) - 1)
+            name + ":" + str(self.count(name) - 1)
         )  # NOTE assume elements in self._nodes never get removed.
         # self._levels[node._level].append(node)
+
+    def count(self, name):
+        """Count the number of nodes with a given name in the graph.
+
+        Args:
+            name (str): The name of the nodes to count.
+
+        Returns:
+            int: The number of nodes with the given name.
+
+        Notes:
+            The count function checks if the input name is a string.
+            If it is, it returns the length of the list of nodes associated with that name in the `_nodes` dictionary.
+            If the input name is not a string, it raises a ValueError indicating that the name must be a string.
+        """
+        assert name in self._nodes, f"Name {name} not found in graph."
+        if self.LEGACY_GRAPH_BEHAVIOR:
+            return len(self._nodes[name])
+        else:
+            return self._nodes[name]
 
     def get(self, name):
         """Retrieve a node from the graph by its name.
@@ -139,7 +164,6 @@ class Graph:
         """
         if not self.LEGACY_GRAPH_BEHAVIOR:
             raise ValueError("Graph.get is not supported when LEGACY_GRAPH_BEHAVIOR is False.")
-
         name, id = name.split(":")
         return self._nodes[name][int(id)]
 
@@ -169,7 +193,10 @@ class Graph:
             int: The total number of nodes in the graph by summing the lengths of all lists in the `_nodes` dictionary.
         """
         # This is the number of nodes in the graph
-        return sum([len(v) for v in self._nodes.values()])
+        if self.LEGACY_GRAPH_BEHAVIOR:
+            return sum([len(v) for v in self._nodes.values()])
+        else:
+            return sum(self._nodes.values())
 
 
 GRAPH = Graph()  # This is a global registry of all the nodes.


### PR DESCRIPTION
The very old code would store all the generated nodes in GRAPH. This can cause memory overflow when there're many. 
I change the default behavior to store ids only.


Please merge the #44  first. I accidentally built this new branch based on it.